### PR TITLE
Custom objects handling and stimulus

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v0.1.6, 10-15-18 -- Objects keys are now an optional argument (allows to use with custom itop extensions)
 v0.1.5, 01-05-18 -- Deactivated duplication test on UserRequest
 v0.1.4, 15-04-18 -- Fix installation bug
 v0.1.3, 15-03-18 -- Minor changes from @gafhyb

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v0.1.7, 10-15-18 -- Added feature to apply stimulus
 v0.1.6, 10-15-18 -- Objects keys are now an optional argument (allows to use with custom itop extensions)
 v0.1.5, 01-05-18 -- Deactivated duplication test on UserRequest
 v0.1.4, 15-04-18 -- Fix installation bug

--- a/itopy/itopy.py
+++ b/itopy/itopy.py
@@ -384,3 +384,43 @@ class Api(object):
 
         request = self.req(data, obj_class)
         return request
+
+    @auth
+    def apply_stimulus(self, obj_class, key, key_value, stimulus, output_fields='*', **kwargs):
+        """
+        Handles the core/apply_stimulus operation in iTOP.
+        Parameters:
+        :param obj_class: iTOP's device class from datamodel
+        :param output_fields: fields to get from iTOP's response
+        :param key: field to identify the the unique object
+        :param key_value: value to the above field
+        :param stimulus: key of the stimulus
+        :param **kwargs: any field needed in stimulus
+        """
+
+        data = {
+            'operation': 'core/apply_stimulus',
+            'comment': self.auth_user + ' (api)',
+            'class': obj_class,
+            'stimulus': stimulus,
+            'output_fields': output_fields,
+            'fields': {
+            },
+            'key': {
+                key: key_value
+            }
+        }
+
+        if key == 'key':
+            data['key'] = key_value
+
+        # do not allow empty values in parameters
+        for kkey, kvalue in kwargs.items():
+            if kvalue:
+                data['fields'][kkey] = kvalue
+            if not kvalue:
+                return 'Parameter not valid'
+
+        request = self.req(data, obj_class)
+        return request
+

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="itopy",
-    version="0.1.5",
+    version="0.1.6",
     author="Jonatas Baldin",
     author_email="jonatas.baldin@gmail.com",
     packages=["itopy"],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="itopy",
-    version="0.1.6",
+    version="0.1.7",
     author="Jonatas Baldin",
     author_email="jonatas.baldin@gmail.com",
     packages=["itopy"],


### PR DESCRIPTION
Hi,

Custom extensions may use custom classes. It would make no sense to add those classes to the dictionary of objects. So I added an argument to the constructor to allow dict definition from call.

I also needed to be able to apply stimulus, according to documentation (https://www.itophub.io/wiki/page?id=2_5_0%3Aadvancedtopics%3Arest_json&s%5B0%5D=api#operationcore_apply_stimulus).

Have a nice day,

Virgile